### PR TITLE
ConfigProvider/Config should be Descriptor/Describable

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
@@ -89,9 +89,16 @@ public abstract class AbstractConfigProvider extends ConfigProvider implements S
 		this.save();
 	}
 
-	/**
-	 * @see hudson.model.Saveable#save()
+    // backward compatibility
+    @Override
+    public String getDisplayName() {
+        return getConfigDescription().getName();
+    }
+
+    /**
+     * Overridden for backward compatibility to let subtype customize the file name.
 	 */
+    @Override
 	public void save() {
 		if (BulkChange.contains(this))
 			return;
@@ -103,7 +110,10 @@ public abstract class AbstractConfigProvider extends ConfigProvider implements S
 		}
 	}
 
-	protected void load() {
+    /**
+     * Overridden for backward compatibility to let subtype customize the file name.
+	 */
+	public void load() {
 		XmlFile xml = getConfigXml();
 		if (xml.exists()) {
 			try {
@@ -118,6 +128,7 @@ public abstract class AbstractConfigProvider extends ConfigProvider implements S
 		return new XmlFile(Jenkins.XSTREAM, new File(Jenkins.getInstance().getRootDir(), this.getXmlFileName()));
 	}
 
-	protected abstract String getXmlFileName();
-
+	protected String getXmlFileName() {
+        return getClass().getName()+".xml";
+    }
 }

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
@@ -59,9 +59,6 @@ public abstract class AbstractConfigProvider extends ConfigProvider implements S
 	}
 
 	@Override
-	public abstract ConfigDescription getConfigDescription();
-
-	@Override
 	public String getProviderId() {
 		return ID_PREFIX;
 	}

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
@@ -38,53 +38,24 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class AbstractConfigProvider extends ConfigProvider implements Saveable {
+/**
+ * Backward compatibility layer for old subtypes of {@link ConfigProvider}
+ * 
+ * @deprecated as of 1.2.
+ *      Extend {@link AbstractConfigProviderImpl} directly.
+ */
+public abstract class AbstractConfigProvider extends AbstractConfigProviderImpl {
 
 	protected final String ID_PREFIX = this.getClass().getSimpleName() + ".";
-
-	protected Map<String, Config> configs = new HashMap<String, Config>();
 
 	public AbstractConfigProvider() {
 		load();
 	}
 
-	@Override
-	public Collection<Config> getAllConfigs() {
-		return Collections.unmodifiableCollection(configs.values());
-	}
-
-	@Override
-	public Config getConfigById(String configId) {
-		return configs.get(configId);
-	}
-
-	@Override
-	public String getProviderId() {
-		return ID_PREFIX;
-	}
-
-	@Override
-	public boolean isResponsibleFor(String configId) {
-		return configId != null && configId.startsWith(ID_PREFIX);
-	}
-
-	@Override
-	public Config newConfig() {
-		String id = this.getProviderId() + System.currentTimeMillis();
-		return new Config(id, null, null, null);
-	}
-
-	@Override
-	public void remove(String configId) {
-		configs.remove(configId);
-		this.save();
-	}
-
-	@Override
-	public void save(Config config) {
-		configs.put(config.id, config);
-		this.save();
-	}
+    @Override
+    public String getProviderId() {
+        return ID_PREFIX;
+    }
 
     // backward compatibility
     @Override

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.lib.configprovider;
+
+import org.jenkinsci.lib.configprovider.model.Config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Partial default implementation of {@link ConfigProvider}.
+ * 
+ * Subtype must call the {@link #load()} method in the constructor.
+ * 
+ * @author Kohsuke Kawaguchi
+ */
+public abstract class AbstractConfigProviderImpl extends ConfigProvider {
+
+	protected Map<String, Config> configs = new HashMap<String, Config>();
+
+	public AbstractConfigProviderImpl() {
+	}
+
+	@Override
+	public Collection<Config> getAllConfigs() {
+		return Collections.unmodifiableCollection(configs.values());
+	}
+
+	@Override
+	public Config getConfigById(String configId) {
+		return configs.get(configId);
+	}
+
+	@Override
+	public String getProviderId() {
+		return getId();
+	}
+
+	@Override
+	public boolean isResponsibleFor(String configId) {
+		return configId != null && configId.startsWith(getProviderId());
+	}
+
+	@Override
+	public Config newConfig() {
+		String id = this.getProviderId() + "." + System.currentTimeMillis();
+		return new Config(id, null, null, null);
+	}
+
+	@Override
+	public void remove(String configId) {
+		configs.remove(configId);
+		this.save();
+	}
+
+	@Override
+	public void save(Config config) {
+		configs.put(config.id, config);
+		this.save();
+	}
+}

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -65,8 +65,13 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
 	 * of
 	 * 
 	 * @return the description
+     * @deprecated as of 1.2
+     *      Use {@link #getDisplayName()} for {@link ConfigDescription#name},
+     *      and {@code newInstanceDetail.jelly} view for {@link ConfigProvider} replaces the {@link ConfigDescription#description} field.
 	 */
-	public abstract ConfigDescription getConfigDescription();
+	public ConfigDescription getConfigDescription() {
+        return new ConfigDescription(getDisplayName(),"");
+    }
 
 	/**
 	 * The content type of the configs this provider manages. e.g. can be used

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -25,6 +25,7 @@ package org.jenkinsci.lib.configprovider;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ConfigDescription;
@@ -43,7 +44,7 @@ import java.util.Collection;
  *
  * @author domi
  */
-public abstract class ConfigProvider implements ExtensionPoint {
+public abstract class ConfigProvider extends Descriptor<Config> implements ExtensionPoint {
 
 	/**
 	 * All registered {@link ConfigProvider}s.

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -33,11 +33,15 @@ import org.jenkinsci.lib.configprovider.model.ContentType;
 import java.util.Collection;
 
 /**
- * A ConfigProvider is able to manage different configuration files (see:
- * {@link Config})
+ * A ConfigProvider represents a configuration file (such as Maven's settings.xml)
+ * where the user can choose its actual content among several {@linkplain Config concrete contents} that are pre-configured.
  * 
+ * <p>
+ * {@link ConfigProvider} is an extension point, and should be implemented and instantiated by
+ * each kind of configuration. This abstraction doesn't define where the configuration is placed,
+ * or how/when it's used &mdash; those semantics should be introduced by a specific instance of {@link ConfigProvider}.
+ *
  * @author domi
- * 
  */
 public abstract class ConfigProvider implements ExtensionPoint {
 

--- a/src/main/java/org/jenkinsci/lib/configprovider/maven/GlobalMavenSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/maven/GlobalMavenSettingsProvider.java
@@ -18,6 +18,8 @@ package org.jenkinsci.lib.configprovider.maven;
 /**
  * @author Olivier Lamy
  * @since 1.1
+ * @deprecated
+ *      Use hudson.maven.settings.GlobalMavenSettingsProvider defined in the maven plugin.
  */
 public interface GlobalMavenSettingsProvider {
 	// no op only a marker interface

--- a/src/main/java/org/jenkinsci/lib/configprovider/maven/MavenSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/maven/MavenSettingsProvider.java
@@ -25,7 +25,9 @@ package org.jenkinsci.lib.configprovider.maven;
 
 /**
  * @author Olivier Lamy
- * @since @since 1.1
+ * @since 1.1
+ * @deprecated
+ *      Use hudson.maven.settings.MavenSettingsProvider defined in the maven plugin.
  */
 public interface MavenSettingsProvider {
 	// no op only a marker interface

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -23,9 +23,7 @@
  */
 package org.jenkinsci.lib.configprovider.model;
 
-import hudson.model.AbstractDescribableImpl;
 import hudson.model.Describable;
-import hudson.model.Descriptor;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -83,6 +81,14 @@ public class Config implements Serializable, Describable<Config> {
         throw new IllegalStateException("Unable to find the owner provider for ID="+id);
     }
 
+    /**
+     * Alias for {@link #getProvider()}
+     */
+    public ConfigProvider getProvider() {
+        return getDescriptor();
+        
+    }
+    
 	@Override
 	public String toString() {
 		return "[Config: id=" + id + ", name=" + name + "]";

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -23,16 +23,17 @@
  */
 package org.jenkinsci.lib.configprovider.model;
 
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
 
 /**
- * Represents a configuration file. A Config object is always managed by one
- * specific {@link org.jenkinsci.lib.configprovider.ConfigProvider}
- * 
+ * Represents a particular configuration file and its content.
+ *
+ * A Config object "belongs to" a {@link ConfigProvider} instance.
+ *
  * @author domi
- * 
  */
 public class Config implements Serializable {
 
@@ -40,8 +41,22 @@ public class Config implements Serializable {
 	 * a unique id along all providers!
 	 */
 	public final String id;
+
+    /**
+     * Human readable display name that distinguishes this {@link Config} instance among
+     * other {@link Config} instances.
+     */
 	public final String name;
+
+    /**
+     * Any note that the author of this configuration wants to associate with this.
+     * Jenkins doesn't use this. Can be null.
+     */
 	public final String comment;
+
+    /**
+     * Content of the file as-is.
+     */
 	public final String content;
 
 	@DataBoundConstructor
@@ -51,6 +66,19 @@ public class Config implements Serializable {
 		this.comment = comment;
 		this.content = content;
 	}
+
+    /**
+     * Gets the {@link ConfigProvider} that owns and manages this config.
+     *
+     * @return never null.
+     */
+    public ConfigProvider getOwner() {
+        for (ConfigProvider p : ConfigProvider.all()) {
+            if (p.isResponsibleFor(id))
+                return p;
+        }
+        throw new IllegalStateException("Unable to find the owner provider for ID="+id);
+    }
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -64,8 +64,7 @@ public class Config implements Serializable, Describable<Config> {
 
 	@DataBoundConstructor
 	public Config(String id, String name, String comment, String content) {
-        if (id==null)   throw new IllegalArgumentException();
-		this.id = id;
+		this.id = id == null ? String.valueOf(System.currentTimeMillis()) : id;
 		this.name = name;
 		this.comment = comment;
 		this.content = content;

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -23,6 +23,9 @@
  */
 package org.jenkinsci.lib.configprovider.model;
 
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -35,7 +38,7 @@ import java.io.Serializable;
  *
  * @author domi
  */
-public class Config implements Serializable {
+public class Config implements Serializable, Describable<Config> {
 
 	/**
 	 * a unique id along all providers!
@@ -61,7 +64,8 @@ public class Config implements Serializable {
 
 	@DataBoundConstructor
 	public Config(String id, String name, String comment, String content) {
-		this.id = id == null ? String.valueOf(System.currentTimeMillis()) : id;
+        if (id==null)   throw new IllegalArgumentException();
+		this.id = id;
 		this.name = name;
 		this.comment = comment;
 		this.content = content;
@@ -72,7 +76,7 @@ public class Config implements Serializable {
      *
      * @return never null.
      */
-    public ConfigProvider getOwner() {
+    public ConfigProvider getDescriptor() {
         for (ConfigProvider p : ConfigProvider.all()) {
             if (p.isResponsibleFor(id))
                 return p;

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigDescription.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigDescription.java
@@ -24,13 +24,17 @@
 package org.jenkinsci.lib.configprovider.model;
 
 
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+
 /**
  * Describes the {@link Config} a {@link org.jenkinsci.lib.configprovider.ConfigProvider}
  * is able to handle. This
  * information can be used for display in the UI.
  * 
  * @author domi
- * 
+ * @deprecated as of 1.2
+ *      {@link ConfigProvider#getDisplayName()} should be overridden for the {@link #name} field,
+ *      and {@code newInstanceDetail.jelly} view for {@link ConfigProvider} replaces the {@link #description} field.
  */
 public class ConfigDescription {
 


### PR DESCRIPTION
I was working on an unrelated pull request and discovered this library.

Given what it does, I think it makes a lot of sense for this to extend from Describable/Descriptor.
- It makes `ConfigProvider`, its relationship to `Config`, its life cycle, and persistence model easier to grok for those who've been working with Jenkins
- It makes the config provider useful for other plugins by allowing it to come with its own standard UI.
- Various taglibs in the core can be leveraged to work with configs, such as `newInstanceDetail.jelly` for allowing arbitrary HTML in the description, `/lib/hudson/newFromList/new` tag for an instant "new config" UI.

I've also tentatively marked `GlobalMavenSettingsProvider` deprecated, given that the Maven plugin appears to define this already. If this supercedes the other, then please revert it, but we should then remove the duplicate from the maven plugin.
